### PR TITLE
Add call_monitor() function void argument for pthread

### DIFF
--- a/fuzzotron.c
+++ b/fuzzotron.c
@@ -319,7 +319,7 @@ int main(int argc, char** argv) {
     return 1;
 }
 
-void * call_monitor(){
+void * call_monitor(void * arg){
     monitor(mon_args.file, mon_args.regex);
     return NULL;
 }

--- a/fuzzotron.h
+++ b/fuzzotron.h
@@ -53,7 +53,7 @@ struct worker_args {
 };
 
 int main(int argc, char** argv);
-void * call_monitor();
+void * call_monitor(void * arg);
 void * timer_job(void * args);
 void * worker(void * worker_args);
 int pid_exists(int pid);


### PR DESCRIPTION
# Before

```
# make
cc -W -g -O3   -c -o fuzzotron.o fuzzotron.c
fuzzotron.c: In function ‘main’:
fuzzotron.c:222:49: error: passing argument 3 of ‘pthread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
  222 |             rc = pthread_create(&monitor, NULL, call_monitor, NULL);
      |                                                 ^~~~~~~~~~~~
      |                                                 |
      |                                                 void * (*)(void)
In file included from fuzzotron.c:16:
/usr/include/pthread.h:204:36: note: expected ‘void * (*)(void *)’ but argument is of type ‘void * (*)(void)’
  204 |                            void *(*__start_routine) (void *),
      |                            ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from fuzzotron.c:31:
fuzzotron.h:56:8: note: ‘call_monitor’ declared here
   56 | void * call_monitor();
      |        ^~~~~~~~~~~~
fuzzotron.c:289:23: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (5 chars into 4 available) [-Wunterminated-string-initialization]
  289 |     char spinner[4] = "|/-\\";
      |                       ^~~~~~~
make: *** [<builtin>: fuzzotron.o] Error 1
```

# After

```
# make
cc -W -g -O3   -c -o fuzzotron.o fuzzotron.c
fuzzotron.c: In function ‘main’:
fuzzotron.c:289:23: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (5 chars into 4 available) [-Wunterminated-string-initialization]
  289 |     char spinner[4] = "|/-\\";
      |                       ^~~~~~~
cc -W -g -O3   -c -o callback.o callback.c
cc -W -g -O3   -c -o generator.o generator.c
cc -W -g -O3   -c -o monitor.o monitor.c
cc -W -g -O3   -c -o sender.o sender.c
cc -W -g -O3   -c -o trace.o trace.c
cc  -o fuzzotron fuzzotron.o callback.o generator.o monitor.o sender.o trace.o -lpcre -lssl -lcrypto -lpthread
cc -W -g -O3   -c -o replay.o replay.c
cc  -o replay replay.o callback.o sender.o -lpcre -lssl -lcrypto -lpthread
Makefile:17: *** radamsa is not available. Download from https://gitlab.com/akihe/radamsa.  Stop.
```